### PR TITLE
Enhancement/sensitivity

### DIFF
--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -11,6 +11,7 @@ use PMPro_Akismet\Akismet;
  * @since 1.0
  */
 function pmpro_akismet_registration_checks( $continue ) {
+    global $pmpro_akismet_extra_nonce;
 
     // Bail if another check already failed.
     if ( ! $continue ) {
@@ -60,6 +61,14 @@ function pmpro_akismet_registration_checks( $continue ) {
         $threshold = 2;
     }
 
+    // If an extra nonce was passed in, raise the threshold.
+    if ( ! empty( $_REQUEST['pmpro_akismet_extra_nonce'] ) && wp_verify_nonce( sanitize_text_field( $_REQUEST['pmpro_akismet_extra_nonce'] ), 'pmpro_akismet_extra_nonce' ) ) {
+        $threshold = 2;
+
+        // Update nonce in case they need to submit again.
+        $pmpro_akismet_extra_nonce = wp_create_nonce( 'pmpro_akismet_extra_nonce' );
+    }
+
     /**
      * Allow for filtering of the threshold. By default the threshold is 2 (blatant spam only) for paid levels and 1 (likely spam) for free levels.
      * @since [TBD]
@@ -80,11 +89,12 @@ function pmpro_akismet_registration_checks( $continue ) {
         }
         
         // Stop checkout if above the threshold.
-        if ( (int)$is_spam >= (int)$threshold ) {
+        if ( (int)$is_spam >= (int)$threshold ) {    
             $continue = false;
-            pmpro_setMessage( esc_html__( 'Sorry, your username or email has been flagged as suspicious.', 'pmpro-akismet' ), 'pmpro_error' );
-        } else {
-            $continue = true;
+            pmpro_setMessage( esc_html__( 'Your username or email has been flagged as suspicious. Double check all fields below and submit again.', 'pmpro-akismet' ), 'pmpro_error' );
+
+            // Set this global to enable the extra check.
+            $pmpro_akismet_extra_nonce = wp_create_nonce( 'pmpro_akismet_extra_nonce' );
         }
     }
 
@@ -93,12 +103,28 @@ function pmpro_akismet_registration_checks( $continue ) {
 add_filter( 'pmpro_registration_checks', 'pmpro_akismet_registration_checks', 10, 1 );
 
 /**
+ * Add an the extra hidden nonce to the checkout form if needed.
+ */
+function pmpro_akismet_add_extra_nonce() {
+    global $pmpro_akismet_extra_nonce;
+
+    if ( ! empty( $pmpro_akismet_extra_nonce ) ) {
+        ?>
+        <input type="hidden" name="pmpro_akismet_extra_nonce" value="<?php echo esc_attr( $pmpro_akismet_extra_nonce ); ?>" />
+        <?php
+    }
+}
+add_action( 'pmpro_checkout_before_submit_button', 'pmpro_akismet_add_extra_nonce' );
+
+/**
  * Show Akismet notice on checkout page below the submit button based on Akismet privacy notice setting.
  * 
  * @since 1.0
  * 
  */
 function pmpro_akismet_show_privacy_notice() {
+    global $pmpro_akismet_extra_nonce;
+    
     // Bail if Akismet show comment setting is set to 'hide'
     if ( 'display' !== apply_filters( 'pmpro_akismet_checkout_privacy_notice' , get_option( 'akismet_comment_form_privacy_notice', 'hide' ) ) ) {
 		return;


### PR DESCRIPTION
Sometime in April we started seeing more false positives from Akismet. This was a good prompt to look at how we were using the API. We probably were relying on their "likely spam" result too much.

This PR updates the plugin to only block emails/etc if they are marked as definite spam from Akisment, as indicated by the presence of `X-akismet-pro-tip: discard` in the header.

We also let users who are marked as "potential spam" checkout if it is for a paid level and everything else clears. Paying for access is a big indicator that the user is not really spamming. We still mark the spammy data as a spam action for the PMPro spam blocker, so if someone is testing credit cards on a paid level checkout page and getting declined, they will actually get blocked twice as fast as before.

In cases where Akismet says the data is likely spam, we (1) track this activity as spam for PMPro's spam filter, (2) create a new nonce to embed into the PMPro checkout form, and (3) ask the user to check their form values and submit again.

#1 above means that folks who are doing repeat spam registrations will get stopped by the PMPro spam filter (which by default blocks IPs when they have more than 10 spammy actions within 15 minutes).

#2 above makes doubly sure that the spam activity is at least coming from an agent on the actual website.

#3 above slows potentially spammy users down, but still allows them to checkout. In practice, folks are often swapping to a better email or just resubmitting. In any case, the PMPro spam filter let's them through if the second nonce is on the checkout page.

In tests, this has lowered the number of real accounts that were getting blocked as spammy, while still stopping a large amount of spam.

If you'd rather use the previous behavior, which blocked all likely spam. You can use the `pmpro_akismet_threshold` filter and have it return 1 instead of 2. A lower number here means "be stricter". By default the threshold is 2 (blatant spam only) for paid levels and 1 (likely spam) for free levels. A threshold of 1 will treat any likely spam as spam.

````
function my_pmpro_akismet_threshold( $threshold ) {
    return 1;
}
add_filter( 'pmpro_akismet_threshold', 'my_pmpro_akismet_threshold' );
````

